### PR TITLE
Added Gradle build pipeline step

### DIFF
--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -22,7 +22,7 @@ jobs:
         run: gradle/actions/setup-gradle@v4
 
       - name: Build worker JAR
-        run: ./gradlew --build-cache assemble
+        run: gradle --build-cache assemble
 
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.8"
 
       - name: Build worker JAR
         run: gradle --build-cache assemble

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -19,9 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Gradle
-        run: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: "8.8"
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build worker JAR
         run: gradle --build-cache assemble

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Gradle
-        run: gradle/actions/setup-gradle@v3
+        run: gradle/actions/setup-gradle@v4
 
       - name: Build worker JAR
         run: ./gradlew --build-cache assemble

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Gradle
         run: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.8"
 
       - name: Build worker JAR
         run: gradle --build-cache assemble

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,6 +1,11 @@
 name: Build Pipeline
 
 on:
+  # Remove push branch once finished testing
+  push:
+    branches:
+      - gradle-build-pipeline-step
+
   pull_request:
     branches:
       - main
@@ -8,35 +13,39 @@ on:
       - closed
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
+    init:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        - name: Setup Java
+          uses: actions/setup-java@v4
+          with:
+            distribution: oracle
+            java-version: 17
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: oracle
-          java-version: 17
+        - name: Setup Gradle
+          uses: gradle/actions/setup-gradle@v4
+          with:
+            gradle-version: "8.8"
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: "8.8"
+    release:
+      runs-on: ubuntu-latest
+      needs: init
 
-      - name: Build worker JAR
-        run: gradle --build-cache assemble
+      steps:
+        - name: Build worker JAR
+          run: gradle --build-cache assemble
 
-      - name: Build Docker image of application
-        run: docker build -t bp3global/c7-rest-worker .
+        - name: Build Docker image of application
+          run: docker build -t bp3global/c7-rest-worker .
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: "bp3docker"
-          password: ${{ secrets.DOCKERHUB_BP3DOCKER }}
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: "bp3docker"
+            password: ${{ secrets.DOCKERHUB_BP3DOCKER }}
 
-      - name: Push Docker image to Docker Hub
-        run: docker push bp3global/c7-rest-worker
+        - name: Push Docker image to Docker Hub
+          run: docker push bp3global/c7-rest-worker

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -18,8 +18,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build worker JAR file
-        run: docker run --mount type=bind,src=$(PWD),dst=/builds -w /builds gradle:jdk17 gradle --build-cache assemble
+      - name: Setup Gradle
+        run: gradle/actions/setup-gradle@v3
+
+      - name: Build worker JAR
+        run: ./gradle --build-cache assemble
 
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,11 +1,9 @@
 name: Build Pipeline
 
 on:
-  # Remove push branch once finished testing
   push:
     branches:
       - gradle-build-pipeline-step
-
   pull_request:
     branches:
       - main
@@ -13,39 +11,35 @@ on:
       - closed
 
 jobs:
-    init:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+  release:
+    runs-on: ubuntu-latest
+    steps:
 
-        - name: Setup Java
-          uses: actions/setup-java@v4
-          with:
-            distribution: oracle
-            java-version: 17
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Setup Gradle
-          uses: gradle/actions/setup-gradle@v4
-          with:
-            gradle-version: "8.8"
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: oracle
+          java-version: 17
 
-    release:
-      runs-on: ubuntu-latest
-      needs: init
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.8"
 
-      steps:
-        - name: Build worker JAR
-          run: gradle --build-cache assemble
+      - name: Build worker JAR
+        run: gradle --build-cache assemble
 
-        - name: Build Docker image of application
-          run: docker build -t bp3global/c7-rest-worker .
+      - name: Build Docker image of application
+        run: docker build -t bp3global/c7-rest-worker .
 
-        - name: Login to Docker Hub
-          uses: docker/login-action@v3
-          with:
-            username: "bp3docker"
-            password: ${{ secrets.DOCKERHUB_BP3DOCKER }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: "bp3docker"
+          password: ${{ secrets.DOCKERHUB_BP3DOCKER }}
 
-        - name: Push Docker image to Docker Hub
-          run: docker push bp3global/c7-rest-worker
+      - name: Push Docker image to Docker Hub
+        run: docker push bp3global/c7-rest-worker

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: oracle
+          java-version: 17
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,6 +1,9 @@
 name: Build Pipeline
 
 on:
+  push:
+    branches:
+      - gradle-build-pipeline-step
   pull_request:
     branches:
       - main
@@ -14,6 +17,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Build worker JAR file
+        run: docker run --mount type=bind,src=$(PWD),dst=/builds -w /builds gradle:jdk17 gradle --build-cache assemble
 
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,9 +1,6 @@
 name: Build Pipeline
 
 on:
-  push:
-    branches:
-      - gradle-build-pipeline-step
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -22,7 +22,7 @@ jobs:
         run: gradle/actions/setup-gradle@v3
 
       - name: Build worker JAR
-        run: ./gradle --build-cache assemble
+        run: ./gradlew --build-cache assemble
 
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .


### PR DESCRIPTION
This fixes the issue with the Docker image build by the GH pipeline that was not assembling the Spring Boot JAR file and therefore the Docker container failed when running the REST connector app.

Have added Gradle assembly step so that the Spring Boot `app.jar` is generated that can then be packaged up into the Docker build. The project is setup to use Gradle v8.8 so this has been stipulated as well.

Have also had to add a Java setup step to ensure the Gradle assembly step is running against the correct JVM version (17) as required by the project.

The Docker build has been tested against `bp3global/c7-rest-worker:latest` and now works.
