### PR TITLE
Split into build and release jobs

### DIFF
--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -54,6 +54,7 @@ jobs:
         run: | 
           ls -al
           cd build/libs
+          pwd
           ls -al
 
       - name: Build Docker image of application

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,10 +1,6 @@
 name: Build Pipeline
 
 on:
-  push:
-    branches:
-      - split-steps
-
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -50,13 +50,6 @@ jobs:
           name: worker-jar
           path: build/libs
 
-      - name: LS
-        run: | 
-          ls -al
-          cd build/libs
-          pwd
-          ls -al
-
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -14,8 +14,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      uploaded-jar-id: ${{ steps.upload-jar.outputs.artifact-id }}
 
     steps:
       - name: Checkout repository
@@ -36,9 +34,9 @@ jobs:
         run: gradle --build-cache assemble
 
       - name: Upload JAR
-        id: upload-jar
         uses: actions/upload-artifact@v4
         with:
+          name: worker-jar
           path: build/libs/*.jar
           retention-days: 1
 
@@ -46,6 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: worker-jar
+          path: build/libs
+
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -50,6 +50,14 @@ jobs:
           name: worker-jar
           path: build/libs
 
+      - name: LS
+        run: | 
+          ls -al
+          cd build/libs
+          pwd
+          ls -al
+          cd ../..
+
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: init
+    needs: build
     steps:
 
       - name: Build Docker image of application

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -50,16 +50,18 @@ jobs:
           name: worker-jar
           path: build/libs
 
-      - name: LS
-        run: | 
-          ls -al
-          cd build/libs
-          pwd
-          ls -al
-          cd ../..
+#      - name: LS
+#        run: |
+#          ls -al
+#          cd build/libs
+#          pwd
+#          ls -al
+#          cd ../..
 
       - name: Build Docker image of application
-        run: docker build -t bp3global/c7-rest-worker .
+        run: |
+          ls -al
+          docker build -t bp3global/c7-rest-worker .
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -31,9 +31,7 @@ jobs:
           gradle-version: "8.8"
 
       - name: Assemble worker JAR
-        run: |
-          gradle --build-cache assemble
-          ls -al
+        run: gradle --build-cache assemble
 
       - name: Cache JAR
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: init
     steps:
 
       - name: Build Docker image of application

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -50,6 +50,12 @@ jobs:
           name: worker-jar
           path: build/libs
 
+      - name: LS
+        run: | 
+          ls -al
+          cd build/libs
+          ls -al
+
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -8,7 +8,7 @@ on:
       - closed
 
 jobs:
-  release:
+  init:
     runs-on: ubuntu-latest
     steps:
 
@@ -26,6 +26,10 @@ jobs:
         with:
           gradle-version: "8.8"
 
+  release:
+    runs-on: ubuntu-latest
+    needs: init
+    steps:
       - name: Build worker JAR
         run: gradle --build-cache assemble
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Assembled worker JAR's
-          path: /build/libs
+          path: /build/libs/*.jar
           retention-days: 1
 
   release:

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -31,18 +31,20 @@ jobs:
           gradle-version: "8.8"
 
       - name: Assemble worker JAR
-        run: gradle --build-cache assemble
+        run: |
+          gradle --build-cache assemble
+          ls -al
 
       - name: Cache JAR
         uses: actions/upload-artifact@v4
         with:
           name: Assembled worker JAR's
-          path: /build/libs/*.jar
+          path: build/libs/*.jar
           retention-days: 1
 
   release:
     runs-on: ubuntu-latest
-    needs: init
+    needs: build
     steps:
 
       - name: Build Docker image of application

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -47,24 +47,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-#      - name: Download JAR
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: worker-jar
-#          path: build/libs
-
-#      - name: LS
-#        run: |
-#          ls -al
-#          cd build/libs
-#          pwd
-#          ls -al
-#          cd ../..
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: worker-jar
+          path: build/libs
 
       - name: Build Docker image of application
-        run: |
-          ls -al
-          docker build -t bp3global/c7-rest-worker .
+        run:  docker build -t bp3global/c7-rest-worker .
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -44,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
 #      - name: Download JAR
 #        uses: actions/download-artifact@v4
 #        with:

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -1,6 +1,10 @@
 name: Build Pipeline
 
 on:
+  push:
+    branches:
+      - split-steps
+
   pull_request:
     branches:
       - main
@@ -8,7 +12,7 @@ on:
       - closed
 
 jobs:
-  init:
+  build:
     runs-on: ubuntu-latest
     steps:
 
@@ -26,12 +30,20 @@ jobs:
         with:
           gradle-version: "8.8"
 
+      - name: Assemble worker JAR
+        run: gradle --build-cache assemble
+
+      - name: Cache JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: Assembled worker JAR's
+          path: /build/libs/*.jar
+          retention-days: 1
+
   release:
     runs-on: ubuntu-latest
     needs: init
     steps:
-      - name: Build worker JAR
-        run: gradle --build-cache assemble
 
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Assembled worker JAR's
-          path: /build/libs/*.jar
+          path: /build/libs
           retention-days: 1
 
   release:

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -14,8 +14,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
+    outputs:
+      uploaded-jar-id: ${{ steps.upload-jar.outputs.artifact-id }}
 
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -30,13 +32,13 @@ jobs:
         with:
           gradle-version: "8.8"
 
-      - name: Assemble worker JAR
+      - name: Assemble JAR
         run: gradle --build-cache assemble
 
-      - name: Cache JAR
+      - name: Upload JAR
+        id: upload-jar
         uses: actions/upload-artifact@v4
         with:
-          name: Assembled worker JAR's
           path: build/libs/*.jar
           retention-days: 1
 
@@ -44,7 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-
       - name: Build Docker image of application
         run: docker build -t bp3global/c7-rest-worker .
 

--- a/.github/workflows/build-pipeline.yaml
+++ b/.github/workflows/build-pipeline.yaml
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: worker-jar
-          path: build/libs
+#      - name: Download JAR
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: worker-jar
+#          path: build/libs
 
 #      - name: LS
 #        run: |


### PR DESCRIPTION
This PR splits the single release job into two jobs, one to build the Spring Boot app JAR, and one to release the Docker image to Docker Hub.

The built JAR file is uploaded to a cache using the upload artifact action in the build job, and then downloaded using the download artifact action in the release job.

This has been tested and I can run the published Docker container locally. I tested the trigger by temporarily adding the following to the workflow.

```
on:
  push:
    branches:
      - split-steps
```
