### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,16 @@ RUN apk add --no-cache \
         curl \
         openjdk17-jre-headless
 
-# Add files from the build
-ADD . /worker
-
-# and set the workign directory
+ENTRYPOINT ["./docker-entrypoint.sh"]
 WORKDIR /worker
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+# We want to ensure that we bust the docker build cache whenever the
+# contents of the repo change, i.e. there are new commits (to main).
+# Without busting the cache at this point then we would need to use
+# the --no-cache argument to docker build to ensure that it is refreshed
+# each time it is built - thereby losing the benefit of having the above
+# layers already in the cache.
+ADD https://github.com/BP3/c7-rest-worker/commits /dev/null
+
+# Add files from the build
+ADD . /worker


### PR DESCRIPTION
If the project has changed (but not the Dockerfile) then we need to be sure that we bust the Docker cache otherwise we will not get the expected outcome.