### PR TITLE
Implemented error handling

### DIFF
--- a/element-templates/RESTConnectorTemplate.json
+++ b/element-templates/RESTConnectorTemplate.json
@@ -2,7 +2,9 @@
   "$schema": "https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json",
   "name": "REST Connector",
   "id": "com.bp3:http-json:1",
-  "appliesTo": ["bpmn:ServiceTask"],
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
   "groups": [
     {
       "id": "httpconfig",
@@ -10,15 +12,14 @@
     }
   ],
   "properties": [
-
     {
       "label": "Task Type",
       "type": "Hidden",
       "value": "external",
       "editable": false,
       "binding": {
-	    "type": "property",
-	    "name": "camunda:type"
+        "type": "property",
+        "name": "camunda:type"
       }
     },
     {
@@ -27,22 +28,36 @@
       "editable": false,
       "value": "bp3-http-json",
       "binding": {
- 	    "type": "property",
-	    "name": "camunda:topic"
+        "type": "property",
+        "name": "camunda:topic"
       }
     },
-
     {
       "label": "Method",
       "group": "httpconfig",
       "type": "Dropdown",
       "value": "get",
       "choices": [
-        { "name": "DELETE", "value": "delete" },
-        { "name": "POST",   "value": "post" },
-        { "name": "GET",    "value": "get" },
-        { "name": "PATCH",  "value": "patch" },
-        { "name": "PUT",    "value": "put" }
+        {
+          "name": "DELETE",
+          "value": "delete"
+        },
+        {
+          "name": "POST",
+          "value": "post"
+        },
+        {
+          "name": "GET",
+          "value": "get"
+        },
+        {
+          "name": "PATCH",
+          "value": "patch"
+        },
+        {
+          "name": "PUT",
+          "value": "put"
+        }
       ],
       "editable": true,
       "binding": {
@@ -64,9 +79,9 @@
       },
       "constraints": {
         "notEmpty": true,
-        "pattern" : {
-          "value" : "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message" : "Must be a http(s) URL"
+        "pattern": {
+          "value": "^(=|(http://|https://|secrets|\\{\\{).*$)",
+          "message": "Must be a http(s) URL"
         }
       }
     },
@@ -92,7 +107,6 @@
         "name": "httpQueryParams"
       }
     },
-
     {
       "label": "Payload",
       "group": "httpconfig",
@@ -103,7 +117,6 @@
         "name": "httpPayload"
       }
     },
-
     {
       "label": "Result Variable",
       "group": "httpconfig",
@@ -114,7 +127,53 @@
         "name": "httpOutParameter"
       }
     },
-
+    {
+      "label": "Error Handling Method",
+      "description": "Determine how connector errors should be handled and propagated back to the process.",
+      "group": "httpconfig",
+      "type": "Dropdown",
+      "choices": [
+        {
+          "name": "",
+          "value": ""
+        },
+        {
+          "name": "BPMN Error",
+          "value": "BPMNError"
+        },
+        {
+          "name": "Failure",
+          "value": "Failure"
+        }
+      ],
+      "editable": true,
+      "binding": {
+        "type": "camunda:inputParameter",
+        "name": "errorHandlingMethod"
+      }
+    },
+    {
+      "label": "Retries",
+      "description": "Number of retries. Used when using the Failure handling method. If not set this will default to zero.",
+      "group": "httpconfig",
+      "type": "String",
+      "editable": true,
+      "binding": {
+        "type": "camunda:inputParameter",
+        "name": "retries"
+      }
+    },
+    {
+      "label": "Retry backoff",
+      "description": "Backoff period between retries in seconds. Used when using the Failure handling method. If not set this will default to zero.",
+      "group": "httpconfig",
+      "type": "String",
+      "editable": true,
+      "binding": {
+        "type": "camunda:inputParameter",
+        "name": "retryBackoff"
+      }
+    },
     {
       "label": "Async before?",
       "type": "Boolean",

--- a/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
@@ -97,7 +97,7 @@ public class C7RESTConnector implements ExternalTaskHandler {
             // complete the external task
             externalTaskService.complete(externalTask, variables);
         } catch(ConnectorException e) {
-            log.error("CONNECTOR_ERROR: {}", e.getLocalizedMessage(), e.fillInStackTrace());
+            log.error("CONNECTOR_ERROR: {}", e.getLocalizedMessage(), e);
 
             String errorHandlingMethod = (String) getVariable(externalTask, PARAM_ERROR_HANDLING_METHOD, String.class);
 

--- a/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
@@ -68,7 +68,6 @@ public class C7RESTConnector implements ExternalTaskHandler {
         Map<String, String> httpHeaders = (Map<String, String>) getVariable(externalTask, PARAM_HTTP_HEADERS, Map.class);
         Map<String, String> httpQueryParams = (Map<String, String>) getVariable(externalTask, PARAM_HTTP_PARAMETERS, Map.class);
         String outputVariableName = (String) getVariable(externalTask, PARAM_OUTPUT_VARIABLE, String.class);
-        String errorHandlingMethod = (String) getVariable(externalTask, PARAM_ERROR_HANDLING_METHOD, String.class);
 
         // validate configuration...
         assert httpMethod != null : "HTTP method must not be null";
@@ -99,6 +98,8 @@ public class C7RESTConnector implements ExternalTaskHandler {
             externalTaskService.complete(externalTask, variables);
         } catch(ConnectorException e) {
             log.error("CONNECTOR_ERROR: {}", e.getLocalizedMessage(), e.fillInStackTrace());
+
+            String errorHandlingMethod = (String) getVariable(externalTask, PARAM_ERROR_HANDLING_METHOD, String.class);
 
             if (errorHandlingMethod != null) {
                 log.debug("CONNECTOR_ERROR: Handling as '{}'", errorHandlingMethod);

--- a/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
@@ -121,7 +121,7 @@ public class C7RESTConnector implements ExternalTaskHandler {
                             e.getLocalizedMessage());
                     case "Failure" -> {
                         int retriesLeft;
-                        if (Objects.isNull(externalTask.getRetries())) {
+                        if (externalTask.getRetries() == null) {
                             retriesLeft = totalRetries;
                         } else {
                             retriesLeft = externalTask.getRetries() - 1;

--- a/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
@@ -104,22 +104,22 @@ public class C7RESTConnector implements ExternalTaskHandler {
             if (errorHandlingMethod != null) {
                 log.debug("CONNECTOR_ERROR: Handling as '{}'", errorHandlingMethod);
 
-                int totalRetries = 0; // Default to zero if not set
-                String retriesParam = (String) getVariable(externalTask, PARAM_RETRIES, String.class);
-                if (retriesParam != null) {
-                    totalRetries = Integer.parseInt(retriesParam);
-                }
-
-                long retryBackoff = 0; // Default to zero if not set
-                String retryBackoffParam = (String) getVariable(externalTask, PARAM_RETRY_BACKOFF, String.class);
-                if (retryBackoffParam != null) {
-                    retryBackoff = Long.parseLong(retryBackoffParam);
-                }
-
                 switch(errorHandlingMethod) {
                     case "BPMNError" -> externalTaskService.handleBpmnError(externalTask, "CONNECTOR_ERROR",
                             e.getLocalizedMessage());
                     case "Failure" -> {
+                        int totalRetries = 0; // Default to zero if not set
+                        String retriesParam = (String) getVariable(externalTask, PARAM_RETRIES, String.class);
+                        if (retriesParam != null) {
+                            totalRetries = Integer.parseInt(retriesParam);
+                        }
+
+                        long retryBackoff = 0; // Default to zero if not set
+                        String retryBackoffParam = (String) getVariable(externalTask, PARAM_RETRY_BACKOFF, String.class);
+                        if (retryBackoffParam != null) {
+                            retryBackoff = Long.parseLong(retryBackoffParam);
+                        }
+
                         int retriesLeft;
                         if (externalTask.getRetries() == null) {
                             retriesLeft = totalRetries;

--- a/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RESTConnector.java
@@ -70,18 +70,6 @@ public class C7RESTConnector implements ExternalTaskHandler {
         String outputVariableName = (String) getVariable(externalTask, PARAM_OUTPUT_VARIABLE, String.class);
         String errorHandlingMethod = (String) getVariable(externalTask, PARAM_ERROR_HANDLING_METHOD, String.class);
 
-        int totalRetries = 0; // Default to zero if not set
-        String retriesParam = (String) getVariable(externalTask, PARAM_RETRIES, String.class);
-        if (Objects.nonNull(retriesParam)) {
-            totalRetries = Integer.parseInt(retriesParam);
-        }
-
-        long retryBackoff = 0; // Default to zero if not set
-        String retryBackoffParam = (String) getVariable(externalTask, PARAM_RETRY_BACKOFF, String.class);
-        if (Objects.nonNull(retriesParam)) {
-            retryBackoff = Long.parseLong(retryBackoffParam);
-        }
-
         // validate configuration...
         assert httpMethod != null : "HTTP method must not be null";
         assert httpURL != null : "HTTP URL must not be null";
@@ -112,8 +100,20 @@ public class C7RESTConnector implements ExternalTaskHandler {
         } catch(ConnectorException e) {
             log.error("CONNECTOR_ERROR: {}", e.getLocalizedMessage(), e.fillInStackTrace());
 
-            if (Objects.nonNull(errorHandlingMethod)) {
+            if (errorHandlingMethod != null) {
                 log.debug("CONNECTOR_ERROR: Handling as '{}'", errorHandlingMethod);
+
+                int totalRetries = 0; // Default to zero if not set
+                String retriesParam = (String) getVariable(externalTask, PARAM_RETRIES, String.class);
+                if (retriesParam != null) {
+                    totalRetries = Integer.parseInt(retriesParam);
+                }
+
+                long retryBackoff = 0; // Default to zero if not set
+                String retryBackoffParam = (String) getVariable(externalTask, PARAM_RETRY_BACKOFF, String.class);
+                if (retryBackoffParam != null) {
+                    retryBackoff = Long.parseLong(retryBackoffParam);
+                }
 
                 switch(errorHandlingMethod) {
                     case "BPMNError" -> externalTaskService.handleBpmnError(externalTask, "CONNECTOR_ERROR",


### PR DESCRIPTION
I have added error handling so that you can specify if you want any errors to be propagated up as BPMN errors or failures (incidents).

![image](https://github.com/user-attachments/assets/920ab107-82ac-48f6-a3d6-fbb55ef0b79f)

# Template Configuration
If you set it to `BPMN Error`, then it will pass based an error code and message that can be handled by using an Error boundary event, e.g.:

![image](https://github.com/user-attachments/assets/84610dfc-65e5-46a5-9909-22a281d97a5c)

![image](https://github.com/user-attachments/assets/0731b082-a1dc-4c61-b0df-544f8f82ff12)

If you set it to `Failure`, then it will keep retrying based on the `Retries` and `Retry backoff` properties, then it will raise an incident in the process, e.g.:

![image](https://github.com/user-attachments/assets/62488a4b-cade-428e-8866-230821bf32fd)

# Process Test
The following process test shows three calls. The first is to a valid URL, the second and third to invalid URL's but handled differently. The failure has been retried three times and then an incident was raised:

![image](https://github.com/user-attachments/assets/0e07f3be-6870-4e44-81c4-6d789453516b)
