### PR TITLE
Allows URL to be dynamically defined from an expression

### DIFF
--- a/element-templates/RESTConnectorTemplate.json
+++ b/element-templates/RESTConnectorTemplate.json
@@ -78,7 +78,11 @@
         "name": "httpURL"
       },
       "constraints": {
-        "notEmpty": true
+        "notEmpty": true,
+        "pattern": {
+          "value": "^(=|(http://|https://|secrets|\\{\\{|\\$\\{).*$)",
+          "message": "Must be a http(s) URL"
+        }
       }
     },
     {

--- a/element-templates/RESTConnectorTemplate.json
+++ b/element-templates/RESTConnectorTemplate.json
@@ -81,7 +81,7 @@
         "notEmpty": true,
         "pattern": {
           "value": "^(=|(http://|https://|secrets|\\{\\{|\\$\\{).*$)",
-          "message": "Must be a http(s) URL"
+          "message": "Must be a valid http(s) URL, secret or expression"
         }
       }
     },

--- a/element-templates/RESTConnectorTemplate.json
+++ b/element-templates/RESTConnectorTemplate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@camunda/element-templates-json-schema/resources/schema.json",
-  "name": "REST Connector",
+  "name": "BP3 REST Connector",
   "id": "com.bp3:http-json:1",
   "appliesTo": [
     "bpmn:ServiceTask"

--- a/element-templates/RESTConnectorTemplate.json
+++ b/element-templates/RESTConnectorTemplate.json
@@ -78,11 +78,7 @@
         "name": "httpURL"
       },
       "constraints": {
-        "notEmpty": true,
-        "pattern": {
-          "value": "^(=|(http://|https://|secrets|\\{\\{).*$)",
-          "message": "Must be a http(s) URL"
-        }
+        "notEmpty": true
       }
     },
     {


### PR DESCRIPTION
The URL format is currently enforced by a regex, but it does not allow `${expression}`, so this has been added to the allowed character sequence in the regex pattern.

![image](https://github.com/user-attachments/assets/13c3ba4e-a2d2-4d59-95f0-927b25de274d)
