### PR TITLE
Catch HTTP properties setup exceptions so we can handle as BPMN error or failures

### DIFF
--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -69,20 +69,21 @@ public final class C7RestConnector implements ExternalTaskHandler {
         if (httpMethod == null || httpMethod.isBlank()) {
             httpMethod = "GET";
         }
-        String httpURL = externalTask.getVariable(PARAM_HTTP_URL);
-        if (httpURL == null || httpURL.isBlank()) {
-            throw new RuntimeException("HTTP URL must not be null");
-        }
 
-        HttpRequest request = httpConnector.createRequest()
-                .url(httpURL)
-                .method(httpMethod);
-        setHeaders(request, asMap(externalTask.getVariable(PARAM_HTTP_HEADERS)));
-        setQueryParams(request, asMap(externalTask.getVariable(PARAM_HTTP_PARAMETERS)));
-        setPayload(request, httpMethod, externalTask.getVariable(PARAM_HTTP_PAYLOAD));
-
-        // call the REST service
         try {
+            String httpURL = externalTask.getVariable(PARAM_HTTP_URL);
+            if (httpURL == null || httpURL.isBlank()) {
+                throw new IllegalArgumentException("HTTP URL must not be null");
+            }
+
+            HttpRequest request = httpConnector.createRequest()
+                    .url(httpURL)
+                    .method(httpMethod);
+            setHeaders(request, asMap(externalTask.getVariable(PARAM_HTTP_HEADERS)));
+            setQueryParams(request, asMap(externalTask.getVariable(PARAM_HTTP_PARAMETERS)));
+            setPayload(request, httpMethod, externalTask.getVariable(PARAM_HTTP_PAYLOAD));
+
+            // call the REST service
             HttpResponse response = request.execute();
 
             // set the output variable

--- a/src/test/java/com/bp3/camunda/camunda7/C7RestConnectorTest.java
+++ b/src/test/java/com/bp3/camunda/camunda7/C7RestConnectorTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.Map;
 import java.util.Set;
 
+import static com.bp3.camunda.camunda7.C7RestConnector.ERROR_METHOD_BPMN_ERROR;
 import static com.bp3.camunda.camunda7.C7RestConnector.PARAM_ERROR_HANDLING_METHOD;
 import static com.bp3.camunda.camunda7.C7RestConnector.PARAM_HTTP_HEADERS;
 import static com.bp3.camunda.camunda7.C7RestConnector.PARAM_HTTP_METHOD;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,11 +88,17 @@ class C7RestConnectorTest {
     }
 
     @Test
-    void givenNoHttpUrlSpecifiedWhenExecutedThenAnExceptionIsThrown() {
+    void givenNoHttpUrlSpecifiedWhenExecutedThenHandledAsBpmnError() {
         when(externalTask.getVariable(PARAM_HTTP_URL))
                 .thenReturn(null);
 
-        assertThrows(RuntimeException.class, () -> connector.execute(externalTask, externalTaskService));
+        when(externalTask.getVariable(PARAM_ERROR_HANDLING_METHOD))
+                .thenReturn(ERROR_METHOD_BPMN_ERROR);
+
+        connector.execute(externalTask, externalTaskService);
+
+        verify(externalTaskService, times(1))
+                .handleBpmnError(externalTask, "CONNECTOR_ERROR", "HTTP URL must not be null");
     }
 
     @Test


### PR DESCRIPTION
Extended the `try` block so that if we have invalid HTTP properties, any exceptions raised here can be caught in the `exception` block, and then we can propagate them up as BPMN Errors or Failures.