### PR TITLE
Allow message send tasks to be bound to a REST worker

### DIFF
--- a/element-templates/bp3-rest-connector.json
+++ b/element-templates/bp3-rest-connector.json
@@ -3,7 +3,8 @@
   "name": "BP3 REST Connector",
   "id": "com.bp3:http-json:1",
   "appliesTo": [
-    "bpmn:ServiceTask"
+    "bpmn:ServiceTask",
+    "bpmn:SendTask"
   ],
   "groups": [
     {


### PR DESCRIPTION
This change allows a message send task to be bound to a REST worker.

In some cases we want to model that messages are being sent to external systems, and be able to model these as message send tasks, for example:

![image](https://github.com/user-attachments/assets/bdfa3aca-79bb-401b-8272-c9c1ef68c660)
