### PR TITLE
Allow worker topic to be configurable

### DIFF
--- a/element-templates/bp3-rest-connector.json
+++ b/element-templates/bp3-rest-connector.json
@@ -25,8 +25,8 @@
     },
     {
       "label": "Worker Topic",
-      "type": "Hidden",
-      "editable": false,
+      "type": "String",
+      "editable": true,
       "value": "bp3-rest-connector",
       "binding": {
         "type": "property",


### PR DESCRIPTION
This PR contains changes to allow the topic the external task client subscribes to, to be configurable.

Currently the usage of the `@ExternalTaskSubscription` limits the topic name to be static (i.e. hardcoded topic name). This cannot be dynamically set using an expression. Therefore, we have to create the external task client manually where we are able to dynamically set the topic name.

The topic name can be set using the following Docker environment variable parameter:
`-e TOPIC_NAME=<Topic name>`

If this is not set, then it will default to `bp3-rest-connector`.

The topic name can be set via the connector template in the Desktop Modeller via the now exposed `Worker Topic` property.

![image](https://github.com/user-attachments/assets/4cdc9ca9-2360-453f-845d-ee33bf95ebda)
