### PR TITLE
Updated to Camunda version 7.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ docker run -it --rm --name gradle \
 ```
 The build can be modified using the following environment variables
 
-| Environment Variable        | Description                                    | Default |
-|-----------------------------|------------------------------------------------|---------|
-| CONNECTOR_VERSION           | The version to give to the built artifact(s)   | 0.0.1-SNAPSHOT |
-| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.22.0  |
-| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Cliet to use            | 1.6.0 |
+| Environment Variable        | Description                                           | Default |
+|-----------------------------|-------------------------------------------------------|--------|
+| CONNECTOR_VERSION           | The version to give to the built artifact(s)          | 0.0.1-SNAPSHOT |
+| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.22.0 |
+| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Client to use         | 1.6.0 |
 
 ## Building the docker image locally
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ docker run -it --rm --name gradle \
 ```
 The build can be modified using the following environment variables
 
-| Environment Variable        | Description                                    | Default        |
-|-----------------------------|------------------------------------------------|----------------|
+| Environment Variable        | Description                                    | Default |
+|-----------------------------|------------------------------------------------|---------|
 | CONNECTOR_VERSION           | The version to give to the built artifact(s)   | 0.0.1-SNAPSHOT |
-| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.22.0         |
-| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Cliet to use            | 1.6.0          |
+| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.22.0  |
+| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Cliet to use            | 1.6.0 |
 
 ## Building the docker image locally
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ The build can be modified using the following environment variables
 | Environment Variable        | Description                                    | Default        |
 |-----------------------------|------------------------------------------------|----------------|
 | CONNECTOR_VERSION           | The version to give to the built artifact(s)   | 0.0.1-SNAPSHOT |
-| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.21.0  |
-| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Cliet to use            | 1.6.0 |
+| CAMUNDA_VERSION             | The version of Camunda 7 that we are building against | 7.22.0         |
+| CAMUNDA_HTTP_CLIENT_VERSION | The version of the Camunda HTTP Cliet to use            | 1.6.0          |
 
 ## Building the docker image locally
 
 ```bash
-docker build -t c7-rest-worker:7.21.0 .
+docker build -t c7-rest-worker:7.22.0 .
 ```
 
 # Running the worker
@@ -119,7 +119,7 @@ The simplest way to run the docker image is as follows
 $ docker run -it --rm \
     --name c7-worker \
     -e ENGINE_ENDPOINT=http://c7host.mynet/engine-rest \
-          bp3/camunda7/c7-rest-worker:7.21.0 [options]
+          bp3/camunda7/c7-rest-worker:7.22.0 [options]
           
 where 'options' are a list of flags for the 'java' command, e.g. -Dxxx=yyy
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 springBootVersion=3.3.3
 springDependencyManagementVersion=1.1.6
-camundaVersion=7.21.0
+camundaVersion=7.22.0


### PR DESCRIPTION
Updated dependencies to 7.22 from 7.21. The 7.22 libraries are backwards compatible with Camunda 7.21.

![image](https://github.com/user-attachments/assets/dc2dd3f5-b6e8-4136-9a8a-8102335ba9d8)
