### PR TITLE
Can handle primitive and typed http payloads.

### DIFF
--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -82,7 +82,16 @@ public final class C7RestConnector implements ExternalTaskHandler {
                     .method(httpMethod);
             setHeaders(request, asMap(externalTask.getVariable(PARAM_HTTP_HEADERS)));
             setQueryParams(request, asMap(externalTask.getVariable(PARAM_HTTP_PARAMETERS)));
-            setPayload(request, httpMethod, externalTask.getVariable(PARAM_HTTP_PAYLOAD));
+
+            String httpPayload = null;
+            if (externalTask.getAllVariablesTyped().containsKey(PARAM_HTTP_PAYLOAD)) {
+                Object value = externalTask.getVariableTyped(PARAM_HTTP_PAYLOAD).getValue();
+                if (value != null) {
+                    httpPayload = value.toString();
+                }
+            }
+
+            setPayload(request, httpMethod, httpPayload);
 
             // call the REST service
             HttpResponse response = request.execute();


### PR DESCRIPTION
Allows typed objects to be passed in as the `httpPayload`, as well as primitive types. The `getVariableTyped` method that the code is now using can handle both.

The output below shows a process calling the external task twice, once with a typed map, and the other with a primitive String with the value of "Hello World!":

```
2025-03-18T19:28:15.778Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : EXECUTE EXTERNAL TASK: Activity_0q8tun2 / 23b7d76f-042f-11f0-905c-2a4aa071ef35
2025-03-18T19:28:15.779Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : ALL VARIABLES: {retries=3, httpOutParameter=response, payload={key1=value1, key2=value2, key3={innerKey=innerValue}}, httpStatusCodeParameter=statusCode, httpURL=http://httpbin.org/anything, httpQueryParams=null, errorHandlingMethod=Failure, httpHeaders=null, retryBackoff=10, httpMethod=POST, httpPayload={key1=value1, key2=value2, key3={innerKey=innerValue}}}
2025-03-18T19:28:17.859Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : RESPONSE: {
  "args": {}, 
  "data": "{key1=value1, key2=value2, key3={innerKey=innerValue}}", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept-Encoding": "gzip,deflate", 
    "Content-Length": "54", 
    "Host": "httpbin.org", 
    "User-Agent": "Apache-HttpClient/4.5.14 (Java/17.0.12)", 
    "X-Amzn-Trace-Id": "Root=1-67d9c94f-29e99bb40111c4f75f5c198a"
  }, 
  "json": null, 
  "method": "POST", 
  "origin": "51.9.193.226", 
  "url": "http://httpbin.org/anything"
}

2025-03-18T19:28:17.860Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : STATUS_CODE: 200
2025-03-18T19:28:18.238Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : EXTERNAL TASK EXECUTED: Activity_0q8tun2 / 23b7d76f-042f-11f0-905c-2a4aa071ef35
2025-03-18T19:28:18.245Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : EXECUTE EXTERNAL TASK: Activity_10evbo2 / 252e4af4-042f-11f0-905c-2a4aa071ef35
2025-03-18T19:28:18.245Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : ALL VARIABLES: {httpStatusCodeParameter=statusCode, httpQueryParams=null, httpHeaders=null, retryBackoff=10, httpMethod=POST, httpPayload=Hello World!, retries=3, httpOutParameter=response, payload=Hello World!, httpURL=http://httpbin.org/anything, response={
  "args": {}, 
  "data": "{key1=value1, key2=value2, key3={innerKey=innerValue}}", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept-Encoding": "gzip,deflate", 
    "Content-Length": "54", 
    "Host": "httpbin.org", 
    "User-Agent": "Apache-HttpClient/4.5.14 (Java/17.0.12)", 
    "X-Amzn-Trace-Id": "Root=1-67d9c94f-29e99bb40111c4f75f5c198a"
  }, 
  "json": null, 
  "method": "POST", 
  "origin": "51.9.193.226", 
  "url": "http://httpbin.org/anything"
}
, errorHandlingMethod=Failure, statusCode=200}
2025-03-18T19:28:20.060Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : RESPONSE: {
  "args": {}, 
  "data": "Hello World!", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept-Encoding": "gzip,deflate", 
    "Content-Length": "12", 
    "Host": "httpbin.org", 
    "User-Agent": "Apache-HttpClient/4.5.14 (Java/17.0.12)", 
    "X-Amzn-Trace-Id": "Root=1-67d9c952-2ac8b2dd19745596059eccf8"
  }, 
  "json": null, 
  "method": "POST", 
  "origin": "51.9.193.226", 
  "url": "http://httpbin.org/anything"
}

2025-03-18T19:28:20.060Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : STATUS_CODE: 200
2025-03-18T19:28:20.068Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : EXTERNAL TASK EXECUTED: Activity_10evbo2 / 252e4af4-042f-11f0-905c-2a4aa071ef35
```

Below are screen shots from Cockpit showing the two calls with each variable type:

* Typed payload:
![image](https://github.com/user-attachments/assets/b1e07fb4-2e04-4a02-858c-19295d498ceb)

* Primitive String payload:
![image](https://github.com/user-attachments/assets/0da69712-347c-4306-af0a-f4a048198cbc)


