### PR TITLE
Fixed lock duration property and added lock duration debug

### DIFF
--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -65,6 +65,7 @@ public final class C7RestConnector implements ExternalTaskHandler {
     public void execute(final ExternalTask externalTask, final ExternalTaskService externalTaskService) {
         log.debug("EXECUTE EXTERNAL TASK: {} / {}", externalTask.getActivityId(), externalTask.getExecutionId());
         log.debug("ALL VARIABLES: {}", externalTask.getAllVariables());
+        log.debug("TASK LOCK EXPIRATION TIME: {}", externalTask.getLockExpirationTime());
 
         String httpMethod = externalTask.getVariable(PARAM_HTTP_METHOD);
         if (httpMethod == null || httpMethod.isBlank()) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ camunda.bpm.client.async-response-timeout=${CLIENT_ASYNC_TIMEOUT:1000}
 #camunda.bpm.client.basic-auth.password=
 
 # Defines for how long the External Tasks are locked until they can be fetched again
-camunda.bpm.client.subscriptions.bp3-http-json.lock-duration=${CLIENT_LOCK_DURATION:10000}
+camunda.bpm.client.subscriptions.bp3-rest-connector.lock-duration=${CLIENT_LOCK_DURATION:10000}
 
 # Defines the maximum number of tasks an external worker instance will pick up when request jobs
 camunda.bpm.client.max-tasks=${MAX_TASKS:10}


### PR DESCRIPTION

```shell
2025-03-25T21:24:24.915Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : TASK LOCK EXPIRATION TIME: Tue Mar 25 21:26:24 UTC 2025
```