### PR TITLE
Added request execution timing logging

### DIFF
--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -95,7 +95,10 @@ public final class C7RestConnector implements ExternalTaskHandler {
             setPayload(request, httpMethod, httpPayload);
 
             // call the REST service
+            final long startTime = System.currentTimeMillis();
             HttpResponse response = request.execute();
+
+            log.debug("REQUEST EXECUTION TIME: {} msec(s)", System.currentTimeMillis() - startTime);
 
             // set the output variable
             log.debug("RESPONSE: {}", response.getResponse());

--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -98,7 +98,7 @@ public final class C7RestConnector implements ExternalTaskHandler {
             final long startTime = System.currentTimeMillis();
             HttpResponse response = request.execute();
 
-            log.debug("REQUEST EXECUTION TIME: {} msec(s)", System.currentTimeMillis() - startTime);
+            log.debug("SERVICE EXECUTION RESPONSE DURATION: {} msec(s)", System.currentTimeMillis() - startTime);
 
             // set the output variable
             log.debug("RESPONSE: {}", response.getResponse());


### PR DESCRIPTION
Have added logging to show how long the service call takes, so we can correlate with a customers service timings. The example below shows how the logging will look:

```
2025-07-24T10:54:22.813+01:00 DEBUG 1769 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : REQUEST EXECUTION TIME: 398 msec(s)
```