### PR TITLE
Added logging of task priority

### DIFF
--- a/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
+++ b/src/main/java/com/bp3/camunda/camunda7/C7RestConnector.java
@@ -66,6 +66,7 @@ public final class C7RestConnector implements ExternalTaskHandler {
         log.debug("EXECUTE EXTERNAL TASK: {} / {}", externalTask.getActivityId(), externalTask.getExecutionId());
         log.debug("ALL VARIABLES: {}", externalTask.getAllVariables());
         log.debug("TASK LOCK EXPIRATION TIME: {}", externalTask.getLockExpirationTime());
+        log.debug("TASK PRIORITY: {}", externalTask.getPriority());
 
         String httpMethod = externalTask.getVariable(PARAM_HTTP_METHOD);
         if (httpMethod == null || httpMethod.isBlank()) {


### PR DESCRIPTION
Log the priority of the task so we can have a visual check as to the order of tasks being processed, e.g.:

```
2025-11-04T14:47:03.808Z DEBUG 12 --- [BP3 C7-REST-Connector] [criptionManager] c.bp3.camunda.camunda7.C7RestConnector   : TASK PRIORITY: 2
```

Note that the branch is named based on the original need to enable priority ordering but this is in fact enabled by default so we only require the logging.